### PR TITLE
Fix AttributeError for 'arith_ast.get_type' to 'arith_ast.elem_type'

### DIFF
--- a/interpreterv1.py
+++ b/interpreterv1.py
@@ -112,7 +112,7 @@ class Interpreter(InterpreterBase):
         if arith_ast.elem_type not in self.op_to_lambda[left_value_obj.type()]:
             super().error(
                 ErrorType.TYPE_ERROR,
-                f"Incompatible operator {arith_ast.get_type} for type {left_value_obj.type()}",
+                f"Incompatible operator {arith_ast.elem_type} for type {left_value_obj.type()}",
             )
         f = self.op_to_lambda[left_value_obj.type()][arith_ast.elem_type]
         return f(left_value_obj, right_value_obj)


### PR DESCRIPTION
Fix: AttributeError: 'Element' object has no attribute 'get_type'.

Changed to 'elem_type'